### PR TITLE
Add xr-site custom element

### DIFF
--- a/app.html
+++ b/app.html
@@ -3538,6 +3538,10 @@ const _makeScreenMesh = () => {
       _selectTab(3);
     } else if (id === 'tab-4') {
       _selectTab(4);
+    } else if (id === 'action-new-scene') {
+      while (root.firstChild) {
+        root.removeChild(root.firstChild);
+      }
     } else if (href) {
       const xrIframe = document.createElement('xr-iframe');
       xrIframe.src = href;

--- a/interface.html
+++ b/interface.html
@@ -249,7 +249,7 @@ ul li a .wrap h3 {
       {{/tab1}}
       {{#tab2}}
       <div class=actions>
-        <a id=action-new class=action>
+        <a id=action-new-scene class=action>
           <div class=border></div>
           <div class=icon>
             <i class="fal fa-sparkles"></i>


### PR DESCRIPTION
This makes `xr-site` a top level element in the browser that tracks the `xr-iframe`s in the site.

The goal is to make this the load/save/copy/paste format for the currently loaded "metasite".